### PR TITLE
Fixed escaping in raw where condition

### DIFF
--- a/src/LaravelNovaSearchable.php
+++ b/src/LaravelNovaSearchable.php
@@ -82,7 +82,10 @@ trait LaravelNovaSearchable
 
         foreach (static::searchableConcatenationColumns() as $columns) {
             if (is_array($columns)) {
-                $query->orWhereRaw(static::concatCondition($query, $columns).' '.static::likeOperator($query)." '%".$search."%'");
+                $query->orWhereRaw(
+                    static::concatCondition($query, $columns).' '.static::likeOperator($query).' ?',
+                    ['%'.$search.'%']
+                );
             } else {
                 $query->orWhere($model->qualifyColumn($columns), static::likeOperator($query), '%'.$search.'%');
             }

--- a/tests/SearchConcatenationTest.php
+++ b/tests/SearchConcatenationTest.php
@@ -31,6 +31,18 @@ class SearchConcatenationTest extends TestCase
     }
 
     /** @test */
+    public function it_returns_results_with_correct_escaping()
+    {
+        $user = factory(User::class)->create();
+        $user->last_name = "D'Antonio";
+        $user->save();
+
+        $this->checkResults($user->first_name.' '.$user->last_name, 1);
+
+        $this->checkResults($user->first_name, 1);
+    }
+
+    /** @test */
     public function it_return_no_result()
     {
         $user = factory(User::class)->create();


### PR DESCRIPTION
I had issues with italian last name with apostrophes.

I found out that the raw where condition wasn't properly escaped.

Added failing test, then fixed.