### PR TITLE
Add compatibility with laravel/framework < 7.x

### DIFF
--- a/src/LaravelNovaSearchable.php
+++ b/src/LaravelNovaSearchable.php
@@ -128,13 +128,12 @@ trait LaravelNovaSearchable
     protected static function applyMatchingAnyColumnsSearch($query, $search)
     {
         $model = $query->getModel();
+        $tokens = collect(explode(' ', $search));
 
         foreach (static::searchableMatchingAnyColumns() as $columns) {
-            Str::of($search)
-                ->explode(' ')
-                ->each(function ($item) use ($query, $model, $columns) {
-                    $query->orWhere($model->qualifyColumn($columns), static::likeOperator($query), '%'.$item.'%');
-                });
+           $tokens->each(function ($token) use ($query, $model, $columns) {
+               $query->orWhere($model->qualifyColumn($columns), static::likeOperator($query), '%'.$token.'%');
+           });
         }
 
         return $query;
@@ -251,13 +250,12 @@ trait LaravelNovaSearchable
         return function ($query) use ($columns, $search) {
             $model = $query->getModel();
             $operator = static::likeOperator($query);
+            $tokens = collect(explode(' ', $search));
 
             foreach ($columns as $items) {
-                Str::of($search)
-                    ->explode(' ')
-                    ->each(function ($item) use ($query, $model, $items, $operator) {
-                        $query->orWhere($model->qualifyColumn($items), $operator, '%'.$item.'%');
-                    });
+                $tokens->each(function ($token) use ($query, $model, $items, $operator) {
+                    $query->orWhere($model->qualifyColumn($items), $operator, '%'.$token.'%');
+                });
             }
         };
     }

--- a/src/LaravelNovaSearchable.php
+++ b/src/LaravelNovaSearchable.php
@@ -3,7 +3,6 @@
 namespace AkkiIo\LaravelNovaSearch;
 
 use Closure;
-use Illuminate\Support\Str;
 use function implode;
 use function is_array;
 
@@ -131,9 +130,9 @@ trait LaravelNovaSearchable
         $tokens = collect(explode(' ', $search));
 
         foreach (static::searchableMatchingAnyColumns() as $columns) {
-           $tokens->each(function ($token) use ($query, $model, $columns) {
-               $query->orWhere($model->qualifyColumn($columns), static::likeOperator($query), '%'.$token.'%');
-           });
+            $tokens->each(function ($token) use ($query, $model, $columns) {
+                $query->orWhere($model->qualifyColumn($columns), static::likeOperator($query), '%'.$token.'%');
+            });
         }
 
         return $query;


### PR DESCRIPTION
This package use fluent string operations that were introduced to laravel 7 (see https://laravel.com/docs/7.x/releases)

I replaced this operations with a default `explode` to ensure compatibility with older versions

I believe `SearchMatchingAnyTest` already covers the updated methods but I might be wrong, is there a need to add tests ?